### PR TITLE
fix: blur amount 해결

### DIFF
--- a/src/common/page/detailPage.tsx
+++ b/src/common/page/detailPage.tsx
@@ -72,6 +72,8 @@ const DetailPage = ({navigation}: any) => {
     );
   }
 
+  console.log(detailProfile);
+
   return (
     <SafeAreaView style={styles.container}>
       <ScrollView
@@ -100,12 +102,11 @@ const DetailPage = ({navigation}: any) => {
             style={styles.arrow}>
             <BackArrow />
           </TouchableOpacity>
-          <BlurView
-            style={[styles.blurOverlay, {height: height * 0.4}]}
-            blurAmount={from === 'MainPage' || from === 'SendNungil' ? 15 : 0}
-            reducedTransparencyFallbackColor="black"
-            pointerEvents="none">
-            {(from === 'SendNungil' || from === 'MainPage') && (
+          {(from === 'MainPage' || from === 'SendNungil') && (
+            <BlurView
+              style={styles.blurOverlay}
+              blurAmount={15}
+              reducedTransparencyFallbackColor="black">
               <View style={styles.matchNoticeContainer}>
                 <Text style={styles.matchNoticeTitle}>
                   눈길 매칭 시에만 프로필 사진이 공개돼요
@@ -117,16 +118,16 @@ const DetailPage = ({navigation}: any) => {
                   상대방의 소개글을 유심히 읽어주세요
                 </Text>
               </View>
-            )}
-            <View style={styles.imgBox}>
-              <Text style={styles.imgText}>{detailProfile.nickname}</Text>
-              <Text style={styles.imgAddText}>
-                {new Date().getFullYear() -
-                  parseInt(detailProfile.birthdate.substring(0, 4), 10)}
-                세 | {detailProfile.companyName}
-              </Text>
-            </View>
-          </BlurView>
+            </BlurView>
+          )}
+          <View style={styles.imgBox}>
+            <Text style={styles.imgText}>{detailProfile.nickname}</Text>
+            <Text style={styles.imgAddText}>
+              {new Date().getFullYear() -
+                parseInt(detailProfile.birthdate.substring(0, 4), 10)}
+              세 | {detailProfile.companyName}
+            </Text>
+          </View>
         </View>
         <View>
           {from === 'ReceivedNungil' && (
@@ -199,7 +200,7 @@ const DetailPage = ({navigation}: any) => {
             {detailProfile.questionAndAnswerList.map(list => (
               <View style={styles.qna}>
                 <Text style={styles.qna_Q}>{list.questionTitle}</Text>
-                <Text style={styles.qna_A}>{list.questionSubTitle}</Text>
+                <Text style={styles.qna_A}>{list.answer}</Text>
               </View>
             ))}
           </View>

--- a/src/detail/DetailProfile.tsx
+++ b/src/detail/DetailProfile.tsx
@@ -34,7 +34,7 @@ const DetailProfile = ({navigation}: any) => {
     tattoo: null,
     smoke: null,
     marriagePlan: null,
-    mbti: '',
+    mbtiType: '',
     grossSalary: 0,
     workArrangementList: [],
     scale: '',

--- a/src/detail/funnelPages/SetMBTI.tsx
+++ b/src/detail/funnelPages/SetMBTI.tsx
@@ -25,8 +25,8 @@ const 엠비티아이 = ({
   });
 
   useEffect(() => {
-    if (value?.mbti) {
-      const mbtiValues = value.mbti.split('');
+    if (value?.mbtiType) {
+      const mbtiValues = value.mbtiType.split('');
       setSelectedOptions({
         ei: mbtiValues[0] || null,
         sn: mbtiValues[1] || null,
@@ -34,7 +34,7 @@ const 엠비티아이 = ({
         jp: mbtiValues[3] || null,
       });
     }
-  }, [value?.mbti]);
+  }, [value?.mbtiType]);
 
   const handleSelect = (group: MBTIGroup, option: string | number) => {
     setSelectedOptions(prevOptions => ({...prevOptions, [group]: option}));
@@ -50,7 +50,7 @@ const 엠비티아이 = ({
           .map(group => selectedOptions[group as MBTIGroup] || 'X')
           .join('');
 
-        await handleDetailProfileValue?.('mbti', mbtiValue);
+        await handleDetailProfileValue?.('mbtiType', mbtiValue);
         onNext();
       }}
       isBtnActive={!Object.values(selectedOptions).includes(null)}>

--- a/src/detail/types/detailProfileAPITypes.ts
+++ b/src/detail/types/detailProfileAPITypes.ts
@@ -4,7 +4,7 @@ export interface detailProfileTypes {
   tattoo: boolean;
   smoke: boolean;
   marriagePlan: number;
-  mbti: string;
+  mbtiType: string;
   grossSalary: number;
   workArrangementList: string[];
   scale: string;

--- a/src/nungilList/components/NungilListLayout.tsx
+++ b/src/nungilList/components/NungilListLayout.tsx
@@ -4,7 +4,6 @@ import {
   View,
   Image,
   Text,
-  useWindowDimensions,
   TouchableOpacity,
   StyleSheet,
 } from 'react-native';
@@ -14,12 +13,7 @@ import {BlurView} from '@react-native-community/blur';
 import {useNavigation} from '@react-navigation/native';
 
 interface LayoutProps {
-  status:
-    | 'RECEIVED'
-    | 'SENT'
-    | 'ACCEPTED_SENT'
-    | 'ACCEPTED_RECEIVED'
-    | ('RECEIVED' | 'SENT' | 'ACCEPTED_SENT' | 'ACCEPTED_RECEIVED')[];
+  status: 'RECEIVED' | 'SENT' | ('ACCEPTED_SENT' | 'ACCEPTED_RECEIVED')[];
   from: string;
 }
 
@@ -74,7 +68,7 @@ const NungilListLayout = ({status, from}: LayoutProps) => {
       console.log(
         `${
           Array.isArray(status) ? status.join(', ') : status
-        } 눈길 리스트 조회 에러:`,
+        } 눈길 리스트 조회 에러 :`,
         err,
       );
     }
@@ -97,11 +91,15 @@ const NungilListLayout = ({status, from}: LayoutProps) => {
                 source={{uri: profile.imageUrlList[0]}}
                 style={styles.profileImg}
               />
-              <BlurView
-                blurAmount={status === 'SENT' ? 15 : 0}
-                reducedTransparencyFallbackColor="black"
-                style={styles.blurView}
-              />
+              {status === 'SENT' ? (
+                <BlurView
+                  blurAmount={15}
+                  reducedTransparencyFallbackColor="black"
+                  style={styles.blur}
+                />
+              ) : (
+                <></>
+              )}
               <View style={styles.infoBox}>
                 <Text style={styles.infoName}>{profile.nickname}</Text>
                 <Text style={styles.infoText}>
@@ -127,7 +125,7 @@ const styles = StyleSheet.create({
   scrollContainer: {
     flexDirection: 'row',
     flexWrap: 'wrap',
-    justifyContent: 'flex-start',
+    justifyContent: 'space-between',
   },
   item: {
     flex: 0,
@@ -145,7 +143,7 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
-  blurView: {
+  blur: {
     position: 'absolute',
     top: 0,
     left: 0,


### PR DESCRIPTION
# 에러사항

**1. BlurView의 blurAmount 속성값 내 숫자가 아닌 조건부 코드 작성 시 에러 발생**
**2. 디테일 페이지 이동 시 null Point Exception 발생**

## 수정사항

(1) 이미지 블러 처리를 위한 blurview 코드에 대해 기존의 **blurAmount 속성 내 조건부 처리 구현**에서 조건부 코드를 밖으로 빼내어 blurAmount의 값으로 **숫자값만 존재하게끔 수정**함. 더불어, 기존의 styleSheet 스타일링과 inline 스타일링의 혼용으로 이루어진 구조에서 height 값까지 styleSheet으로 빼내어 코드를 간결하게 함과 동시에 필요하지 않은 속성을 제거함.

(2) null Point Exception에 대해 눈길 상세 조회 api 응답값을 받아보니 **'mbtiType'** 값이 null임을 확인. 원인을 파악해보니 상세 프로필 등록 api의 명세에는 값이 'mbti'라 되어 있으나 스웨거 상에는 'mbtiType'이라 명시되어 있는 것을 통해 서버에 'mbtiType'으로 넘겨주어야 함을 확인하여 mbti를 입력받던 funnel page 및 type 선언 부분에 대해 수정 완료.

### 기존 코드

```
<BlurView
            style={[styles.blurOverlay, {height: height * 0.4}]}
            blurAmount={from === 'MainPage' || from === 'SendNungil' ? 15 : 0}
            reducedTransparencyFallbackColor="black"
            pointerEvents="none">
```

### 수정된 코드

```
{(from === 'MainPage' || from === 'SendNungil') && (
            <BlurView
              style={styles.blurOverlay}
              blurAmount={15}
              reducedTransparencyFallbackColor="black">
```